### PR TITLE
Fix uncaught error from yield without arguments

### DIFF
--- a/lib/rules/delegate-effects.js
+++ b/lib/rules/delegate-effects.js
@@ -22,6 +22,10 @@ module.exports = {
         const tracker = createTracker();
 
         function isSagaCall(node) {
+            if (node === null) {
+                return false;
+            }
+            
             switch (node.type) {
                 case 'CallExpression':
                     return tracker.isNodeEffect(node);


### PR DESCRIPTION
👋  big fan of this project! makes the migration to `typed-redux-saga` much simpler :)

I did notice a minor bug - looks like yield expressions without arguments (i.e. just `yield;`) cause a crash due to the following section:
https://github.com/jambit/eslint-plugin-typed-redux-saga/blob/2998c4a5c3b121537b0e7417d06106ef6e5f1655/lib/rules/delegate-effects.js#L40-L43

With no arguments, `node.argument` is `null` which `isSagaCall` isn't able to handle.

I've added a tiny check to just return `false` for that case since it's clearly not a saga call, though the defensive logic could be moved to consumers of `isSagaCall` as well.